### PR TITLE
build(deps): bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,11 +41,11 @@
 	"devDependencies": {
 		"@commitlint/cli": "^19.8.1",
 		"@commitlint/config-conventional": "^19.8.1",
-		"@eslint/compat": "^1.3.0",
+		"@eslint/compat": "^1.3.1",
 		"@types/eslint-plugin-security": "^3.0.0",
 		"husky": "^9.1.7",
 		"licensee": "^11.1.1",
-		"prettier": "^3.6.0",
+		"prettier": "^3.6.2",
 		"typescript": "~5.8.3"
 	},
 	"peerDependencies": {
@@ -53,11 +53,11 @@
 	},
 	"dependencies": {
 		"@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
-		"@eslint/js": "^9.29.0",
-		"eslint-config-prettier": "^10.1.5",
+		"@eslint/js": "^9.31.0",
+		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-import": "^2.32.0",
-		"eslint-plugin-jsdoc": "^51.2.1",
-		"eslint-plugin-n": "^17.20.0",
+		"eslint-plugin-jsdoc": "^51.4.1",
+		"eslint-plugin-n": "^17.21.0",
 		"eslint-plugin-promise": "^7.2.1",
 		"eslint-plugin-regexp": "^2.9.0",
 		"eslint-plugin-security": "^3.0.1",


### PR DESCRIPTION
gets us passed the vulnerable eslint-config-prettier lot

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [ ] Run `npm test`
- [ ] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [ ] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
