### PR TITLE
fix(index): import jsdoc plugin config, not factory

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -8,7 +8,7 @@ import prettier from "eslint-config-prettier/flat";
 // @ts-ignore: no types exist for this plugin
 import comments from "@eslint-community/eslint-plugin-eslint-comments/configs";
 import imp from "eslint-plugin-import";
-import { jsdoc } from "eslint-plugin-jsdoc";
+import jsdoc from "eslint-plugin-jsdoc";
 import n from "eslint-plugin-n";
 // @ts-ignore: no types exist for this plugin
 import promise from "eslint-plugin-promise";
@@ -19,9 +19,7 @@ import security from "eslint-plugin-security";
 const config = [
 	eslint.configs.recommended,
 	comments.recommended,
-	jsdoc({
-		config: "flat/recommended",
-	}),
+	jsdoc.configs["flat/recommended"],
 	promise.configs["flat/recommended"],
 	regexp.configs["flat/recommended"],
 	security.configs.recommended,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [ ] Run `npm test`
- [ ] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [ ] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
