### PR TITLE
chore(devcontainer): add `onCreateCommand` for chown; only lint in husky

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,7 +27,9 @@
 		"ghcr.io/devcontainers/features/git:1": {},
 		"ghcr.io/devcontainers/features/github-cli:1": {}
 	},
+	// Change owner of the /workspaces folder to the non-root user to avoid permission issues
+	"onCreateCommand": "sudo chown -R node:node /workspaces/",
 	// Use 'postCreateCommand' to run commands after the container is created
-	"postCreateCommand": "npm i",
+	"postCreateCommand": "npm i && npm run prepare",
 	"remoteUser": "node"
 }

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npm run lint:licenses && npm test
+npm run lint:licenses && npm run lint:prettier && npm run lint


### PR DESCRIPTION
Tests are better ran in CI due to be able to test in multiple envs, so have removed from pre-commit hook.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [ ] Run `npm test`
- [ ] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [ ] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
