### PR TITLE
ci(cd): make provenance publishing explicit

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -62,7 +62,7 @@ jobs:
                   npm i --ignore-scripts
                   npm run build --if-present
                   npm pkg delete commitlint devDependencies scripts
-                  npm publish --access public --ignore-scripts
+                  npm publish --access public --ignore-scripts --provenance
 
     publish-ghp:
         name: Publish to GitHub Packages


### PR DESCRIPTION
Security tooling can't tell i'm using npm's oidc for provenance, so add this back in.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
