### PR TITLE
build(.devcontainer): add lockfile; use bookworm for base image

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 	"$schema": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json",
 
 	"name": "Node.js",
-	"image": "mcr.microsoft.com/devcontainers/javascript-node:20",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:20-bookworm",
 
 	"customizations": {
 		"vscode": {
@@ -30,7 +30,6 @@
 	},
 	// Features to add to the dev container. More info: https://containers.dev/features
 	"features": {
-		"ghcr.io/devcontainers/features/git:1": {},
 		"ghcr.io/devcontainers/features/github-cli:1": {}
 	},
 	// Change owner of the /workspaces folder to the non-root user to avoid permission issues

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,18 @@
 version: 2
 updates:
+    - package-ecosystem: devcontainers
+      commit-message:
+          include: scope
+          prefix: build
+      directory: /
+      groups:
+          devcontainers:
+              patterns:
+                  - "ghcr.io/devcontainers/features/*"
+      open-pull-requests-limit: 20
+      schedule:
+          interval: monthly
+
     - package-ecosystem: github-actions
       commit-message:
           include: scope

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 # Auto-generated files
+.devcontainer/devcontainer-lock.json
 .github/release-please/manifest.json
 CHANGELOG.md
 package.json


### PR DESCRIPTION
- Added devcontainer-lock.json to pin github-cli feature version
- Removed redundant git feature (pre-installed in base image)
- Switched base image from default trixie to bookworm for stability

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
