### PR TITLE
build(dependabot): remove redundant includes cooldown array

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
           prefix: build
       cooldown:
           default-days: 7
-          include:
-              - "*"
       directory: /
       groups:
           devcontainers:
@@ -23,8 +21,6 @@ updates:
           prefix: ci
       cooldown:
           default-days: 7
-          include:
-              - "*"
       directory: /
       groups:
           fdawgs-owned:
@@ -44,8 +40,6 @@ updates:
           include: scope
           prefix: build
       cooldown:
-          include:
-              - "*"
           semver-major-days: 60
           semver-minor-days: 21
           semver-patch-days: 7


### PR DESCRIPTION
All deps included by default, no need for array